### PR TITLE
Draftmancer Export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ resources/.DS_Store
 .DS_Store
 resources/magic-egg-allinone-exporter.mse-export-template/.DS_Store
 resources/magic-egg-allinone-exporter.mse-export-template/.DS_Store
+__pycache__
+.vscode

--- a/deckbuilder.html
+++ b/deckbuilder.html
@@ -539,6 +539,7 @@
 					<option value="copy">Copy decklist</option>
 					<option value="export-dek">Export .dek</option>
 					<option value="export-txt">Export .txt</option>
+					<option value="draftmancer">Export Draftmancer File</option>
 				</select>
 				<input type="file" class="hidden" id="import-file" onclick="this.value=null;">
 			</div>
@@ -697,6 +698,10 @@
 			else if (option.startsWith("export"))
 			{
 				exportFile(option);
+			}
+			else if (option == "draftmancer")
+			{
+				exportDraftmancer();
 			}
 		});
 
@@ -2442,6 +2447,122 @@
 			document.getElementById("file-menu").value = "default";
 		}
 
+		
+		function convertManaCostForDraftmancer(mana_cost) {
+			return mana_cost
+				.replace(/{([A-Z])([A-Z])}/g, "{$1/$2}");
+		}
+
+		async function exportDraftmancer() {	
+			let output_text = "";
+			let cards = new Map();
+			
+			console.log("deck:", deck);
+			
+			for (const card of deck)
+			{
+				const c = JSON.parse(card);
+				if (cards.has(c.card_name))
+				{
+					cards.get(c.card_name).count += 1;
+				}
+				else
+				{
+					cards.set(c.card_name, {...c, count: 1});
+				}
+			}
+
+			const URLDomain = "https://voyager-mtg.github.io"; // FIXME: Shouldn't be hardcoded.
+
+			output_text += `[Settings]
+{
+  "layouts": {
+    "default": {
+      "weight": 1,
+      "slots": {
+        "rare": 1,
+        "uncommon": 3,
+        "common": 10,
+      }
+	}
+  }
+}
+`;
+			output_text += "[CustomCards]\n[\n";
+			for (const c of cards.values())
+			{
+				const img_url = URLDomain + "/sets/" + c.set + "-files/img/" + c.number + "_" + c.card_name + ((c.shape.includes("double")) ? "_front" : "") + "." + c.image_type;
+				output_text += "  {\n";
+				output_text += `    "name": "${c.card_name}",\n`;
+				if(c.cost)
+					output_text += `    "mana_cost": "${convertManaCostForDraftmancer(c.cost)}",\n`;
+				else 
+					output_text += `    "mana_cost": "",\n`;
+				if(c.rarity)
+					output_text += `    "rarity": "${c.rarity}",\n`;
+				if(c.set)
+					output_text += `    "set": "${c.set}",\n`;
+				if(c.number)
+					output_text += `    "collector_number": "${c.number}",\n`;
+				if(c.type) {
+					output_text += `    "type": "${c.type.split(" – ")[0]}",\n`;
+					const subtypes = c.type.split(" – ")[1];
+					if(subtypes)
+						output_text += `    "subtypes": ["${subtypes.split(" ").join("", "")}"],\n`;
+				}
+				if(c.rules_text)
+					output_text += `    "oracle_text": ${JSON.stringify(c.rules_text)},\n`;
+				output_text += `    "image": "${img_url}",\n`;
+				if(c.shape.includes("double")) {
+					const back_url = URLDomain + "/sets/" + c.set + "-files/img/" + c.number + "_" + c.card_name + "_back" + "." + c.image_type;
+					output_text += `    "back": {`
+					output_text += `      "name": "${c.card_name2}",\n`;
+					if(c.cost2)
+						output_text += `      "mana_cost": "${convertManaCostForDraftmancer(c.cost2)}",\n`;
+					else 
+						output_text += `    "mana_cost": "",\n`;
+					if(c.rarity2)
+						output_text += `      "rarity": "${c.rarity2}",\n`;
+					if(c.set2)
+						output_text += `      "set": "${c.set2}",\n`;
+					if(c.number2)
+						output_text += `      "collector_number": "${c.number2}",\n`;
+					if(c.type2) {
+						output_text += `      "type": "${c.type2.split(" – ")[0]}",\n`;
+						const subtypes = c.type2.split(" – ")[1];
+						if(subtypes)
+							output_text += `    "subtypes": ["${subtypes.split(" ").join("", "")}"],\n`;
+					}
+					if(c.rules_text2)
+						output_text += `      "oracle_text": ${JSON.stringify(c.rules_text2)},\n`;
+					output_text += `      "image": "${back_url}",`
+					output_text += `    },\n`;
+				}
+				output_text += "  },\n";
+			}
+			output_text += "]\n";
+
+			const rarities = [...(new Set([...cards.values().map(c => c.rarity)]))];
+
+			for(const r of rarities) {
+				output_text += `[${r}]\n`;
+				for (const c of cards.values()) {
+					if(c.rarity === r) 
+						output_text += `${c.count} ${c.card_name}\n`;
+				}
+			}
+
+			let downloadableLink = document.createElement('a');
+			downloadableLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(output_text));
+			downloadableLink.download = document.getElementById("deck-name").value + ".txt";
+			document.body.appendChild(downloadableLink);
+			downloadableLink.click();
+			document.body.removeChild(downloadableLink);
+
+			document.getElementById("file-menu").value = "default";
+		
+		}
+        
 		function goToSearch() {
 			window.location = ("/search");
 		}


### PR DESCRIPTION
Adds a basic exporter to Draftmancer cube file to the deck builder.

![image](https://github.com/user-attachments/assets/4b0a4cf5-e1b2-4111-b0eb-60d53c8aca3a)

The generated cube file use a custom layout following the card rarities (1 rare/3 unco/10 commons), I don't know if this is actually desirable.
I realized that the MSE exporter already generated cube files (`exports/{set}-files/{set}-draft.txt`), we could extract the '[CustomCards]' header from there rather that re-generating it in JS like I'm doing in this PR.
